### PR TITLE
Avoid MITM attacks by verifying download integrity

### DIFF
--- a/install.js
+++ b/install.js
@@ -3,8 +3,10 @@ var fs = require('fs');
 var path = require('path');
 var os = require('os');
 var unzip = require('unzip');
+var crypto = require('crypto');
 
 var WIX_BINARY_URL = 'http://static.wixtoolset.org/releases/v3.9.1006.0/wix39-binaries.zip'
+var zip_hash = '0f05d338d364b348d20c1ccb79f6103cc5209417382ce1e705ce436ea85fb46f0bc32b75d5f5de9ad62bbda5b2d93ff9f1497370e918d5ef0c3fa12d60308ca1';
 
 var zipPath = path.resolve(os.tmpdir(), 'wix.zip');
 var file = fs.createWriteStream(zipPath);
@@ -15,8 +17,26 @@ var request = http.get(WIX_BINARY_URL, function(response) {
 		process.stdout.write(".");
 	});
 	response.on('end', function() {
-		console.log('Extracting');
-		fs.createReadStream(zipPath).pipe(unzip.Extract({path: path.resolve(__dirname, 'wix-bin')}));
+		console.log('Download complete');
+		console.log('Starting integrity check...');
+
+		// Verify file using hash make MITM harder
+		var fstream = fs.createReadStream(zipPath);
+		var hash = crypto.createHash('sha512');
+		hash.setEncoding('hex');
+
+		fstream.on('end', function() {
+			hash.end();
+			calculated_hash = hash.read();
+			if (zip_hash === calculated_hash){
+				console.log('Extracting');
+				fs.createReadStream(zipPath).pipe(unzip.Extract({path: path.resolve(__dirname, 'wix-bin')}));
+				console.log("Extraction complete")
+			}else{
+				console.log(`File verification failed:\nDownloaded file sha512: ${calculated_hash}`);
+			}
+		});
+		fstream.pipe(hash);
 	})
 });
 

--- a/install.js
+++ b/install.js
@@ -33,7 +33,8 @@ var request = http.get(WIX_BINARY_URL, function(response) {
 				fs.createReadStream(zipPath).pipe(unzip.Extract({path: path.resolve(__dirname, 'wix-bin')}));
 				console.log("Extraction complete")
 			}else{
-				console.log(`File verification failed:\nDownloaded file sha512: ${calculated_hash}`);
+				console.error(`File verification failed:\nDownloaded file sha512: ${calculated_hash}`);
+				process.exit(-1);
 			}
 		});
 		fstream.pipe(hash);

--- a/install.js
+++ b/install.js
@@ -34,7 +34,11 @@ var request = http.get(WIX_BINARY_URL, function(response) {
 				console.log("Extraction complete")
 			}else{
 				console.error(`File verification failed:\nDownloaded file sha512: ${calculated_hash}`);
-				process.exit(-1);
+				fs.unlink(zipPath, function(err) {
+					if (err) throw err;
+					console.log('File deleted');
+					process.exit(-1);
+				});
 			}
 		});
 		fstream.pipe(hash);

--- a/package.json
+++ b/package.json
@@ -11,11 +11,11 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
+    "crypto": "^1.0.1",
     "unzip": "^0.1.11"
   },
-  "repository" :
-  { "type" : "git"
-  , "url" : "https://github.com/rewiredpictures/node-wixtoolset.git"
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/rewiredpictures/node-wixtoolset.git"
   }
-
 }


### PR DESCRIPTION
Exceutable files downloaded trough http: are vulnerable to MiM attacks, since server can be faked and file with dangerous code executed, ideally https should be implemented on the server but in this case, file is not available through https so download is verified with sha512

### If incorrect file is downloaded hash will be different and installation fail
![Captura de pantalla de 2020-08-29 00-52-33](https://user-images.githubusercontent.com/7505980/91618616-86d82d00-e993-11ea-88da-8c180251a81d.png)

### File downloads and verifies correctly
![Captura de pantalla de 2020-08-29 00-43-13](https://user-images.githubusercontent.com/7505980/91617420-b2a5e380-e990-11ea-9fce-ca6c33a3ec02.png)
